### PR TITLE
Implement Keycloak auth and secure test endpoint

### DIFF
--- a/Controllers/TestController.cs
+++ b/Controllers/TestController.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace KeycloakApi.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class TestController : ControllerBase
+    {
+        [HttpGet]
+        [Authorize]
+        public IActionResult Get()
+        {
+            return Ok("This is a protected endpoint");
+        }
+    }
+}

--- a/KeycloakApi.csproj
+++ b/KeycloakApi.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.3" />
   </ItemGroup>
 
 </Project>

--- a/Program.cs
+++ b/Program.cs
@@ -1,8 +1,22 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
+builder.Services.AddControllers();
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
+
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.Authority = builder.Configuration["Keycloak:Authority"];
+        options.RequireHttpsMetadata = false;
+        options.TokenValidationParameters.ValidateAudience = false;
+    });
+
+builder.Services.AddAuthorization();
 
 var app = builder.Build();
 
@@ -12,7 +26,12 @@ if (app.Environment.IsDevelopment())
     app.MapOpenApi();
 }
 
+app.UseAuthentication();
+app.UseAuthorization();
+
 app.UseHttpsRedirection();
+
+app.MapControllers();
 
 app.Run();
 

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Keycloak": {
+    "Authority": "http://localhost:8080/realms/master"
   }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Keycloak": {
+    "Authority": "http://localhost:8080/realms/master"
+  }
 }


### PR DESCRIPTION
## Summary
- configure JWT bearer authentication for Keycloak
- add a simple controller with a protected endpoint
- expose controllers and authentication middleware in `Program.cs`
- add Keycloak settings to configuration files
- reference `Microsoft.AspNetCore.Authentication.JwtBearer`
- update realm to `master` and disable audience validation

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6863e4c5ab288328a4aec9123de6d8ed