### PR TITLE
Enable Keycloak password grant in Swagger

### DIFF
--- a/KeycloakApi.csproj
+++ b/KeycloakApi.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# KeycloakApi
+
+This API demonstrates how to protect ASP.NET endpoints using Keycloak and how to authenticate directly through Swagger UI using the password grant.
+
+## Running
+
+```bash
+# restore dependencies and run the application
+# Keycloak should be running locally and a client named `swagger-ui` must exist
+# with direct access grants enabled.
+
+ dotnet run --project KeycloakApi.csproj
+```
+
+Navigate to `http://localhost:5173/swagger` and use the **Authorize** button. Enter your Keycloak username and password to obtain a token for API calls.


### PR DESCRIPTION
## Summary
- switch Swagger OAuth flow to Resource Owner Password Credentials
- streamline Swagger UI config for password grant
- document providing username and password in Swagger

## Testing
- `dotnet build -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6863ecf790848328b6ac0d65a75e75d7